### PR TITLE
Cleanup double cd when the adblock directory found in adblock-update.sh.

### DIFF
--- a/tools/adblock-update.sh
+++ b/tools/adblock-update.sh
@@ -35,7 +35,7 @@ elif (( $# > 1 ));then
 fi
 
 # look for adblock directory || create
-[[ -d "$DATADIR/luakit/adblock/" ]] && cd "$DATADIR/luakit/adblock/" || mkdir "$DATADIR/luakit/adblock/" && cd "$DATADIR/luakit/adblock/"
+[[ -d "$DATADIR/luakit/adblock/" ]] || mkdir "$DATADIR/luakit/adblock/" && cd "$DATADIR/luakit/adblock/"
 
 # backup the old list
 [[ -f ${listname} ]] && cp -p ${listname} ${listname}.b


### PR DESCRIPTION
It's just a really minor thing.

In bash,  '||' and '&&' has the same precedence, so the line

```
[[ -d "$DATADIR/luakit/adblock/" ]] && cd "$DATADIR/luakit/adblock/" || mkdir "$DATADIR/luakit/adblock/" && cd "$DATADIR/luakit/adblock/"
```

will `cd` into the adblock dir twice if it exist.
I think 

```
[[ -d "$DATADIR/luakit/adblock/" ]] || mkdir "$DATADIR/luakit/adblock/" && cd "$DATADIR/luakit/adblock/"
```

was intended here.
