### PR TITLE
Allow empty url ("") as first argument in adblock-update.sh

### DIFF
--- a/tools/adblock-update.sh
+++ b/tools/adblock-update.sh
@@ -27,7 +27,7 @@ EOF
 # use URL if given else default to easylist.txt
 if (( $# == 1 )) || (( $# == 0 )); then
 	[[ ! -z $1 ]] && [[ $1 == "-h" ]] || [[ $1 == "--help" ]] && usage && exit 0  # check for -hflag
-	listurl="${1-"https://easylist-downloads.adblockplus.org/easylist.txt"}"
+	listurl="${1:-"https://easylist-downloads.adblockplus.org/easylist.txt"}"
 	listname="$(basename ${listurl})"
 elif (( $# > 1 ));then
 	usage


### PR DESCRIPTION
This is a request.

If the first argument to adblock-update.sh is empty ("") it will fail with:

```
basename: missing operand
Try 'basename --help' for more information.
wget: missing URL
Usage: wget [OPTION]... [URL]...

Try `wget --help' for more options.
Error: List Download Failed!
```

I would like if the empty argument would be the same (updating "easylist.txt") as without argument.
This way I could make a script like this:

```
LISTS=(
"" #easylist
"filter-list-url" #another filter
    ...
)

for l in "${LISTS[@]}"; do
  "$UPDATER" "$l"
done
```
