### PR TITLE
External video program, and autoscroll

### DIFF
--- a/autoscroll/init.lua
+++ b/autoscroll/init.lua
@@ -12,7 +12,7 @@
 
 local buf, key = lousy.bind.buf, lousy.bind.key
 
-local config = globals.autoscroll
+local config = globals.autoscroll or {}
 
 local start_buf = config.start_buf or "^,a$"
 
@@ -22,19 +22,24 @@ local stop_key = config.stop_key or ","
 local scroll_step = config.autoscroll_step or 1 -- globals.scroll_step -- (too fast)
 local page_step = globals.page_step or config.page_step or 1.0
 
-local accel = config.acceleration or 5
+local accel    = config.acceleration or 5
+local interval = config.interval or 50
 
 add_binds("normal", {
 			 -- Start autoscroll with a (previously ,a)
        buf(start_buf, "Start autoscroll", function (w) w:set_mode("autoscroll") end),
-})
+                    })
+
+local function prompt_interval(interval)
+   return string.format("-- AUTOSCROLL MODE (%d) --", interval)
+end
 
 add_binds("autoscroll", {
 			 -- Increase scrolling speed
 			 key({}, "+", function (w)
 					w.autoscroll_timer:stop()
 					w.autoscroll_timer.interval = math.max(5, w.autoscroll_timer.interval - accel)
-          w:set_prompt(string.format("-- AUTOSCROLL MODE (%d) --", w.autoscroll_timer.interval))
+          w:set_prompt(prompt_interval(w.autoscroll_timer.interval))
 					w.autoscroll_timer:start()
 			 end),
 
@@ -42,7 +47,7 @@ add_binds("autoscroll", {
 			 key({}, "-", function (w)
 					w.autoscroll_timer:stop()
 					w.autoscroll_timer.interval = w.autoscroll_timer.interval + accel
-          w:set_prompt(string.format("-- AUTOSCROLL MODE (%d) --", w.autoscroll_timer.interval))
+          w:set_prompt(prompt_interval(w.autoscroll_timer.interval))
 					w.autoscroll_timer:start()
 			 end),
 
@@ -68,8 +73,8 @@ end
 new_mode("autoscroll", {
 			-- Start autoscroll timer
 			enter = function (w)
-			   local t = timer{interval=50}
-         w:set_prompt("-- AUTOSCROLL MODE (50) --")
+			   local t = timer{interval=interval}
+         w:set_prompt(prompt_interval(t.interval))
 			   t:add_signal("timeout", function ()
 							   w:scroll { yrel = scroll_step }
 			   end)

--- a/autoscroll/init.lua
+++ b/autoscroll/init.lua
@@ -1,0 +1,87 @@
+-- Autoscroll script for luakit (luakit.org).
+-- Originally by @mason-larobina and then @alexdantas
+-- (https://gist.github.com/mason-larobina/726550)
+-- (https://gist.github.com/alexdantas/7987616)
+--
+-- Install instructions:
+--  * Add to rc.lua before window spawning code
+--  Or
+--  * Save to $XDG_CONFIG_HOME/luakit/autoscroll.lua and
+--    add `require "autoscroll"` to your rc.lua
+----------------------------------------------------------------
+
+local buf, key = lousy.bind.buf, lousy.bind.key
+
+local config = globals.autoscroll
+
+local start_buf = config.start_buf or "^,a$"
+
+local stop_mod = config.stop_modifier or {}
+local stop_key = config.stop_key or ","
+
+local scroll_step = config.autoscroll_step or 1 -- globals.scroll_step -- (too fast)
+local page_step = globals.page_step or config.page_step or 1.0
+
+local accel = config.acceleration or 5
+
+add_binds("normal", {
+			 -- Start autoscroll with a (previously ,a)
+       buf(start_buf, "Start autoscroll", function (w) w:set_mode("autoscroll") end),
+})
+
+add_binds("autoscroll", {
+			 -- Increase scrolling speed
+			 key({}, "+", function (w)
+					w.autoscroll_timer:stop()
+					w.autoscroll_timer.interval = math.max(5, w.autoscroll_timer.interval - accel)
+          w:set_prompt(string.format("-- AUTOSCROLL MODE (%d) --", w.autoscroll_timer.interval))
+					w.autoscroll_timer:start()
+			 end),
+
+			 -- Decrease scrolling speed
+			 key({}, "-", function (w)
+					w.autoscroll_timer:stop()
+					w.autoscroll_timer.interval = w.autoscroll_timer.interval + accel
+          w:set_prompt(string.format("-- AUTOSCROLL MODE (%d) --", w.autoscroll_timer.interval))
+					w.autoscroll_timer:start()
+			 end),
+
+			 -- Default page scroll keybindings,
+			 -- so we can still scroll while autoscrolling.
+			 key({}, "Page_Down", "Scroll page down.",
+           function (w) w:scroll{ ypagerel =  page_step } end),
+
+			 key({}, "Page_Up", "Scroll page up.",
+           function (w) w:scroll{ ypagerel = -page_step } end),
+
+       buf(start_buf, "Stop autoscroll", function (w) w:set_mode("normal") end),
+})
+
+
+if stop_key and not stop_key == "not" then
+   add_binds("autoscroll", {
+                key(stop_mod, stop_key, "Stop autoscroll",
+                    function (w) w:set_mode("normal") end),
+                           })
+end
+
+new_mode("autoscroll", {
+			-- Start autoscroll timer
+			enter = function (w)
+			   local t = timer{interval=50}
+         w:set_prompt("-- AUTOSCROLL MODE (50) --")
+			   t:add_signal("timeout", function ()
+							   w:scroll { yrel = scroll_step }
+			   end)
+			   w.autoscroll_timer = t
+			   t:start()
+			end,
+
+			-- Stop autoscroll timer
+			leave = function (w)
+			   if w.autoscroll_timer then
+				  w.autoscroll_timer:stop()
+				  w.autoscroll_timer = nil
+			   end
+			end,
+})

--- a/use_video_program/init.lua
+++ b/use_video_program/init.lua
@@ -21,9 +21,9 @@ local which = config.which or "mpv"  -- Allows some pre-defined uses.
 local watch_functions = {
    mpv = function(view, uri, finish)
       if geometry == "fullscreen" then
-         luakit.spawn(string.format("mpv --fs %s", uri), finish)
+         luakit.spawn(string.format("mpv --force-window --fs %s", uri), finish)
       else
-         luakit.spawn(string.format("mpv --geometry=%s %s", geometry, uri, finish))
+         luakit.spawn(string.format("mpv --force-window --geometry=%s %s", geometry, uri, finish))
       end
    end,
    cclive = function(view, uri, finish)

--- a/use_video_program/init.lua
+++ b/use_video_program/init.lua
@@ -12,12 +12,12 @@ local use_command = config.use_command or nil
 local vid_cmd = config.vid_cmd or "vid"
 local vidlist_cmd = config.vid_cmd or "vidlist"
 
-local chain = config.chain
-if chain == nil then chain = true end
+function default_true(x) if x == nil then return true else return x end end
+
+local chain = default_true(config.chain)
 
 -- Whether or not to pop up the window.
-local popup_initial = config.popup_initial  -- First in list.
-if popup_initial == nil then popup_initial = true end
+local popup_initial = default_true(config.popup_initial)  -- First in list.
 local popup = config.popup or false
 
 local geometry = config.geometry or "1366x768"

--- a/use_video_program/init.lua
+++ b/use_video_program/init.lua
@@ -1,0 +1,48 @@
+-- (https://github.com/mason-larobina/luakit/wiki/Play-embedded-video-in-external-player)
+----------------------------------------------------------------
+
+local key, buf, but = lousy.bind.key, lousy.bind.buf, lousy.bind.but
+
+local config = globals.use_video_program or {}
+
+local use_mod = config.use_mod or {}
+local use_key = config.use_key or "v"
+local use_command = config.use_command or nil
+
+local geometry = config.geometry or "1366x768"
+   
+local which = config.which or "mpv"  -- Allows some pre-defined uses.
+
+local watch_functions = {
+   mpv = function(view, uri, finish)
+      if geometry == "fullscreen" then
+         luakit.spawn(string.format("mpv --fs %s", uri), finish)
+      else
+         luakit.spawn(string.format("mpv --geometry=%s %s", geometry, uri, finish))
+      end
+   end,
+   cclive = function(view, uri)
+      luakit.spawn(string.format("urxvt -e cclive --stream best --filename-format '%%t.%%s' "
+               .. "--output-dir %q --exec='mplayer \"%%f\"' %q", os.getenv("HOME") .."/downloads", uri), finish)
+   end
+}
+
+local use_function = config.use_function or watch_functions[which] or watch_function.mpv
+
+function activate (w)
+   local uri = w.view.hovered_uri or w.view.uri
+   if uri then
+      use_function(w.view, uri,
+                   function() w:set_prompt("-- VIDEO ENDED --") end)
+   end
+end
+
+if use_key and not (use_key == "not") then
+   add_binds("normal", { key(use_mod, use_key, "View video external program",
+                             function(w) activate(w) end), })
+end
+
+if use_command and not (use_command == "not") then
+   add_binds("normal", { buf(use_command, "View video external program",
+                             function(w) activate(w) end), })
+end

--- a/use_video_program/init.lua
+++ b/use_video_program/init.lua
@@ -8,7 +8,17 @@ local config = globals.use_video_program or {}
 local use_mod = config.use_mod or {}
 local use_key = config.use_key or "v"
 local use_command = config.use_command or nil
+
 local vid_cmd = config.vid_cmd or "vid"
+local vidlist_cmd = config.vid_cmd or "vidlist"
+
+local chain = config.chain
+if chain == nil then chain = true end
+
+-- Whether or not to pop up the window.
+local popup_initial = config.popup_initial  -- First in list.
+if popup_initial == nil then popup_initial = true end
+local popup = config.popup or false
 
 local geometry = config.geometry or "1366x768"
 
@@ -19,14 +29,16 @@ local geometry = config.geometry or "1366x768"
 local which = config.which or "mpv"  -- Allows some pre-defined uses.
 
 local watch_functions = {
-   mpv = function(view, uri, finish)
+   mpv = function(view, uri, finish, pop)
+      -- TODO it doesnt listen to `pop`
       if geometry == "fullscreen" then
          luakit.spawn(string.format("mpv --force-window --fs %s", uri), finish)
       else
-         luakit.spawn(string.format("mpv --force-window --geometry=%s %s", geometry, uri, finish))
+         luakit.spawn(string.format("mpv --force-window --geometry=%s %s", geometry, uri),
+                      finish)
       end
    end,
-   cclive = function(view, uri, finish)
+   cclive = function(view, uri, finish, pop)
       luakit.spawn(string.format("urxvt -e cclive --stream best --filename-format '%%t.%%s' "
                .. "--output-dir %q --exec='mplayer \"%%f\"' %q", os.getenv("HOME") .."/downloads", uri), finish)
    end
@@ -34,24 +46,49 @@ local watch_functions = {
 
 local vid_function = config.vid_function or watch_functions[which] or watch_function.mpv
 
-local function endprompt() w:set_prompt("-- VIDEO ENDED --") end
+local function endprompt(w) return function() w:set_prompt("-- VIDEO ENDED --") end end
 
-local function activate (w)
+local chain_sequence = {}
+
+local function next_in_chain(w, at_end)
+   return function()
+      table.remove(chain_sequence, 1)
+      if #chain_sequence > 0 then
+         vid_function(w.view, chain_sequence[1], next_in_chain(w, at_end, popup))
+      end
+   end
+end
+
+local function bind_fun(w)
    local uri = w.view.hovered_uri or w.view.uri
    if uri then
-      vid_function(w.view, uri, endprompt)
+      if chain then
+         table.insert(chain_sequence, uri)
+         if (#chain_sequence) == 1 then -- One left, get it started.
+            vid_function(w.view, uri, next_in_chain(w), popup_initial)
+         end
+      else
+         vid_function(w.view, uri, endprompt(w), popup_initial)
+      end
    end
 end
 
 if use_key and not (use_key == "not") then
-   add_binds("normal", { key(use_mod, use_key, "View video external program", activate) })
+   add_binds("normal", { key(use_mod, use_key, "View video external program", bind_fun) })
 end
 
 if use_command and not (use_command == "not") then
-   add_binds("normal", { buf(use_command, "View video external program", activate) })
+   add_binds("normal", { buf(use_command, "View video external program", bind_fun) })
 end
 
 if vid_cmd then
    add_cmds({ cmd(vid_cmd, "Use external video program on given URI",
                   function(w,query) vid_function(w.view, query, endprompt) end) })
+end
+
+if vidlist_cmd then
+   add_cmds({ cmd(vidlist_cmd, "List currently queued video/audio URIs",
+                  function(w,query)
+                     w:set_prompt(table.concat(chain_sequence, ",\n"))
+                  end) })
 end

--- a/use_video_program/init.lua
+++ b/use_video_program/init.lua
@@ -11,6 +11,10 @@ local use_command = config.use_command or nil
 local vid_cmd = config.vid_cmd or "vid"
 
 local geometry = config.geometry or "1366x768"
+
+-- TODO possible to figure out the maximized geometry properly?
+--function maximized_geometry() ... end
+--function fullscreen_geometry() ... end
    
 local which = config.which or "mpv"  -- Allows some pre-defined uses.
 

--- a/use_video_program/init.lua
+++ b/use_video_program/init.lua
@@ -1,13 +1,14 @@
 -- (https://github.com/mason-larobina/luakit/wiki/Play-embedded-video-in-external-player)
 ----------------------------------------------------------------
 
-local key, buf, but = lousy.bind.key, lousy.bind.buf, lousy.bind.but
+local key, buf, cmd = lousy.bind.key, lousy.bind.buf, lousy.bind.cmd
 
 local config = globals.use_video_program or {}
 
 local use_mod = config.use_mod or {}
 local use_key = config.use_key or "v"
 local use_command = config.use_command or nil
+local vid_cmd = config.vid_cmd or "vid"
 
 local geometry = config.geometry or "1366x768"
    
@@ -21,28 +22,32 @@ local watch_functions = {
          luakit.spawn(string.format("mpv --geometry=%s %s", geometry, uri, finish))
       end
    end,
-   cclive = function(view, uri)
+   cclive = function(view, uri, finish)
       luakit.spawn(string.format("urxvt -e cclive --stream best --filename-format '%%t.%%s' "
                .. "--output-dir %q --exec='mplayer \"%%f\"' %q", os.getenv("HOME") .."/downloads", uri), finish)
    end
 }
 
-local use_function = config.use_function or watch_functions[which] or watch_function.mpv
+local vid_function = config.vid_function or watch_functions[which] or watch_function.mpv
 
-function activate (w)
+local function endprompt() w:set_prompt("-- VIDEO ENDED --") end
+
+local function activate (w)
    local uri = w.view.hovered_uri or w.view.uri
    if uri then
-      use_function(w.view, uri,
-                   function() w:set_prompt("-- VIDEO ENDED --") end)
+      vid_function(w.view, uri, endprompt)
    end
 end
 
 if use_key and not (use_key == "not") then
-   add_binds("normal", { key(use_mod, use_key, "View video external program",
-                             function(w) activate(w) end), })
+   add_binds("normal", { key(use_mod, use_key, "View video external program", activate) })
 end
 
 if use_command and not (use_command == "not") then
-   add_binds("normal", { buf(use_command, "View video external program",
-                             function(w) activate(w) end), })
+   add_binds("normal", { buf(use_command, "View video external program", activate) })
+end
+
+if vid_cmd then
+   add_cmds({ cmd(vid_cmd, "Use external video program on given URI",
+                  function(w,query) vid_function(w.view, query, endprompt) end) })
 end


### PR DESCRIPTION
The external-video-program is a trivial variation of [the wiki player](https://github.com/mason-larobina/luakit/wiki/Play-embedded-video-in-external-player), it allows adding your own.

The autoscroll is modified [from this](https://gist.github.com/alexdantas/7987616), by @alexdantas, the prompt now tells you the speed aswel.

Both have a single `globals` entry that can set anything and have defaults for everything.
