### PR TITLE
Update ua switch

### DIFF
--- a/uaswitch/init.lua
+++ b/uaswitch/init.lua
@@ -3,7 +3,6 @@
 -- © 2012 Plaque FCC <Reslayer@ya.ru>                     --
 ------------------------------------------------------------
 
-local globals   = globals
 local string    = string
 local type      = type
 local dofile    = dofile
@@ -12,13 +11,10 @@ local error     = error
 local pairs     = pairs
 local ipairs    = ipairs
 local io        = io
-local capi      = { luakit = luakit }
-local lousy     = require ("lousy")
-local util      = lousy.util
-local add_binds, add_cmds = add_binds, add_cmds
-local lfs       = require ("lfs")
+local settings  = require("settings")
 local plugins   = require ("plugins")
-local window    = window
+local window    = require ("window")
+local modes	= require ("modes")
 
 module("plugins.uaswitch")
 
@@ -32,14 +28,14 @@ ua_strings = {}
 function update_views()
     for _, w in pairs(window.bywidget) do
         for _, v in ipairs(w.tabs.children) do
-            v.user_agent = globals.useragent
+            v.user_agent = settings.webview.user_agent
         end
     end
 end
 
 function load_ua_strings()
     ua_strings = {
-        original = string.rep(globals.useragent, 1),
+        original = string.rep(settings.webview.user_agent, 1),
         fakes = {}
     }
     dofile(ua_strings_file)
@@ -60,7 +56,7 @@ function switch_to(alias)
 
     if (useragent) then
         io.stdout:write("uaswitcher: Change to '" .. useragent .."'.\n")
-        globals.useragent = string.rep(useragent, 1)
+        settings.webview.user_agent = string.rep(useragent, 1)
         update_views()
         return
     else
@@ -75,11 +71,10 @@ function load()
 end
 
 -- Add commands.
-local cmd = lousy.bind.cmd
-add_cmds({
-    cmd({"user-agent", "ua"}, function (w, a)
-        switch_to(a)
-    end),
+modes.add_cmds({
+	{ ":user-agent", "Set user-agent string", function (w, a)
+	    switch_to(a.arg)
+	end},
 })
 
 -- Initialise module

--- a/uaswitch/init.lua
+++ b/uaswitch/init.lua
@@ -18,7 +18,7 @@ local modes	= require ("modes")
 
 
 
-ua_strings_file = plugins.plugins_dir .. "uaswitch/ua_strings.lua"
+local ua_strings_file = plugins.plugins_dir .. "uaswitch/ua_strings.lua"
 local _M = {}
 _M.ua_strings = {}
 _M.hide_box = false

--- a/uaswitch/init.lua
+++ b/uaswitch/init.lua
@@ -16,13 +16,12 @@ local plugins   = require ("plugins")
 local window    = require ("window")
 local modes	= require ("modes")
 
-module("plugins.uaswitch")
 
-ua_alias_default = "default"
 
 ua_strings_file = plugins.plugins_dir .. "uaswitch/ua_strings.lua"
-
-ua_strings = {}
+local _M = {}
+_M.ua_strings = {}
+_M.hide_box = false
 
 -- Refresh open filters views (if any)
 function update_views()
@@ -34,24 +33,23 @@ function update_views()
 end
 
 function load_ua_strings()
-    ua_strings = {
+    _M.ua_strings = {
         original = string.rep(settings.webview.user_agent, 1),
-        fakes = {}
+	fakes = dofile (ua_strings_file)
     }
-    dofile(ua_strings_file)
 end
 
 function switch_to(alias)
     if (not alias) then
-        alias = ua_alias_default
+        alias = "default"
     end
     assert(type(alias) == "string", "user agent switch: invalid user agent alias")
     local useragent = nil
     io.stdout:write("uaswitcher: Requested change to '" .. alias .."'.\n")
-    if (alias == ua_alias_default) then
-        useragent = ua_strings.original
+    if (alias == "default") then
+        useragent = _M.ua_strings.original
     else
-        useragent = ua_strings.fakes[alias]
+        useragent = _M.ua_strings.fakes[alias]
     end
 
     if (useragent) then
@@ -64,11 +62,6 @@ function switch_to(alias)
     end
 end
 
-function load()
-    load_ua_strings()
-    -- switch_to(ua_alias_default)
-    switch_to("inferfox") -- And let them choke! ;'D
-end
 
 -- Add commands.
 modes.add_cmds({
@@ -77,5 +70,5 @@ modes.add_cmds({
 	end},
 })
 
--- Initialise module
-load()
+load_ua_strings()
+return _M

--- a/uaswitch/ua_strings.lua
+++ b/uaswitch/ua_strings.lua
@@ -1,5 +1,4 @@
-plugins.uaswitch.ua_strings.fakes = {
-    
+return {
         ["inferfox"]        = "Mozilla/6.0 (compatible; AppleWebKit/latest; like Gecko/20120405; };-> infernal_edition:goto-hell) Firefox/666",
         ["firefox_15"]      = "Mozilla/5.0 (Windows NT 6.1; rv:15.0) Gecko/20120427 Firefox/15.0a1",
         ["firefox_14"]      = "Mozilla/5.0 (Windows NT 6.1; rv:14.0) Gecko/20120405 Firefox/14.0a1",


### PR DESCRIPTION
Uaswitch no longer loads (and prevents the browser from starting). This PR updates `luakit-plugins/uaswitch` to use `modes.add_cmds`, `settings` rather than `globals` and the new `_M` style modules. (I'm assuming this is in line with #15, but that issue's light on details.) 

A few things to pay extra attention to (I'm obviously happy to change anything):
    - `ua_strings.lua` returns its table rather than assigning it (as `_M` can't be seen). 
    - A level of indirection is removed on startup: `load()` which just called `load_ua_strings()` is removed and `load_ua_strings()` called directly.
    - A level of indirection is removed with the default ua handling: `ua_alias_default` is removed and `"default"` used explicitly. (As there was no benefit to having a variable.)

I also have the (2017 era) list of UAs from #16 staged and ready to commit, if you'd like those included in this. (I assumed since there was a separate issue, a separate PR were appropriate).

I also have an enhancement to call a menu to display known UAs staged and ready to commit.